### PR TITLE
新規登録ページ・ログインページのビューの変更

### DIFF
--- a/app/assets/stylesheets/module/user.scss
+++ b/app/assets/stylesheets/module/user.scss
@@ -56,6 +56,10 @@
         font-size: 12px;
         vertical-align: top;
       }
+
+      .error_explanation {
+        color: red;
+      }
     }
 
     .btn {

--- a/app/assets/stylesheets/module/user.scss
+++ b/app/assets/stylesheets/module/user.scss
@@ -17,6 +17,7 @@
     margin: 0 auto;
     .field {
       margin:25px 100px 25px 100px;
+      text-align: center;
 
       .field-label {
         padding: 10px 0;

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -13,7 +13,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create
     @user = User.new(sign_up_params)
     unless @user.valid?
-      flash.now[:alert] = @user.errors.full_messages
+      flash.now[:alert] = "情報を正しく入力してください"
       render :new and return
     end
     session["devise.regist_data"] = {user: @user.attributes}
@@ -26,7 +26,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     @user = User.new(session["devise.regist_data"]["user"])
     @address = Address.new(address_params)
     unless @address.valid?
-      flash.now[:alert] = @address.errors.full_messages
+      flash.now[:alert] = "情報を正しく入力してください"
       render :new_address and return
     end
     @user.build_address(@address.attributes)

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -2,13 +2,15 @@
   %h2 新規アカウントの登録
 .account-page__user-form
   = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|  
-    = render "devise/shared/error_messages", resource: resource
     .field
       .field-label
         = f.label :nickname, "ニックネーム"
         %span.form-require 必須
       .field-input
         = f.text_field :nickname, autofocus: true, autocomplete: "nickname",placeholder: "フリマくん"
+      - if resource.errors.include?(:nickname)
+        .error_explanation
+          = resource.errors.full_messages_for(:nickname).first
     .field
       .field-label
         = f.label :introduction, "自己紹介"
@@ -20,6 +22,9 @@
         %span.form-require 必須
       .field-input
         = f.email_field :email, autofocus: true, autocomplete: "email",placeholder: "xxx@fleamarket.com"
+      - if resource.errors.include?(:email)
+        .error_explanation
+          = resource.errors.full_messages_for(:email).first
     .field
       .field-label
         = f.label :password,"パスワード"
@@ -29,12 +34,18 @@
             (7文字以上の半角英数を入力してください。)
       .field-input
         = f.password_field :password, autocomplete: "password"
+      - if resource.errors.include?(:password)
+        .error_explanation
+          = resource.errors.full_messages_for(:password).first
     .field
       .field-label
         = f.label :password_confirmation,"パスワード（確認用）"
         %span.form-require 必須
       .field-input
         = f.password_field :password_confirmation, autocomplete: "new-password"
+      - if resource.errors.include?(:password_confirmation)
+        .error_explanation
+          = resource.errors.full_messages_for(:password_confirmation).first
     .field
       .field-label
         = f.label :name, "お名前"
@@ -44,6 +55,12 @@
       .field-input
         = f.text_field :family_name, autofocus: true, autocomplete: "family_name",placeholder: "田中"
         = f.text_field :first_name, autofocus: true, autocomplete: "first_name",placeholder: "太郎"
+      - if resource.errors.include?(:family_name)
+        .error_explanation
+          = resource.errors.full_messages_for(:family_name).first
+      - if resource.errors.include?(:first_name)
+        .error_explanation
+          = resource.errors.full_messages_for(:first_name).first
     .field
       .field-label
         = f.label :name_kana, "お名前（カナ）"
@@ -53,12 +70,21 @@
       .field-input
         = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana",placeholder: "タナカ"
         = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana",placeholder: "タロウ"
+      - if resource.errors.include?(:family_name_kana)
+        .error_explanation
+          = resource.errors.full_messages_for(:family_name_kana).first
+      - if resource.errors.include?(:first_name_kana)
+        .error_explanation
+          = resource.errors.full_messages_for(:first_name_kana).first
     .field
       .field-label
         = f.label :birth_date, "生年月日"
         %span.form-require 必須
       .field-input
         = f.date_select :birth_date, use_month_numbers: true,start_year: 1930, end_year: (Time.now.year - 10), default: Date.new(1989, 1, 1)
+      - if resource.errors.include?(:birth_date)
+        .error_explanation
+          = resource.errors.full_messages_for(:birth_date).first
         
     .field
       .field-label
@@ -66,5 +92,8 @@
         %span.form-require 必須
       .field-input
         = f.text_field :phone_number, autofocus: true, autocomplete: "phone_number",placeholder: "080xxxoooo"
+      - if resource.errors.include?(:phone_number)
+        .error_explanation
+          = resource.errors.full_messages_for(:phone_number).first     
     .actions
       = f.submit "次へ", class: 'btn'

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -21,7 +21,7 @@
         = f.label :email, "メールアドレス"
         %span.form-require 必須
       .field-input
-        = f.email_field :email, autofocus: true, autocomplete: "email",placeholder: "xxx@fleamarket.com"
+        = f.text_field :email, autocomplete: "email",placeholder: "xxx@fleamarket.com"
       - if resource.errors.include?(:email)
         .error_explanation
           = resource.errors.full_messages_for(:email).first

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -2,7 +2,6 @@
   %h2 住所情報の登録
 .account-page__address-form
   = form_for(@address) do |f|  
-    = render "devise/shared/error_messages", resource: @address
     .field
       .field-label
         = f.label :name, "お名前"
@@ -12,6 +11,12 @@
       .field-input
         = f.text_field :family_name, autofocus: true, autocomplete: "family_name",placeholder: "田中"
         = f.text_field :first_name, autofocus: true, autocomplete: "first_name",placeholder: "太郎"
+      - if resource.errors.include?(:family_name)
+        .error_explanation
+          = resource.errors.full_messages_for(:family_name).first
+      - if resource.errors.include?(:first_name)
+        .error_explanation
+          = resource.errors.full_messages_for(:first_name).first
     .field
       .field-label
         = f.label :name_kana, "お名前（カナ）"
@@ -21,12 +26,21 @@
       .field-input
         = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana",placeholder: "タナカ"
         = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana",placeholder: "タロウ"
+      - if resource.errors.include?(:family_name_kana)
+        .error_explanation
+          = resource.errors.full_messages_for(:family_name_kana).first
+      - if resource.errors.include?(:first_name_kana)
+        .error_explanation
+          = resource.errors.full_messages_for(:first_name_kana).first
     .field
       .field-label
         = f.label :post_code, "郵便番号"
         %span.form-require 必須
       .field-input
         = f.text_field :post_code, autofocus: true, autocomplete: "post_code",placeholder: "0001111"
+      - if resource.errors.include?(:post_code)
+        .error_explanation
+          = resource.errors.full_messages_for(:post_code).first
     .field
       .field-label
         = f.label :address, "住所"
@@ -39,10 +53,25 @@
         = f.text_field :house_number, autofocus: true, autocomplete: "house_number",placeholder: "番地"
         %br
         = f.text_field :building_name, autofocus: true, autocomplete: "building_name",placeholder: "建物名・部屋番号"
+      - if resource.errors.include?(:prefecture)
+        .error_explanation
+          = resource.errors.full_messages_for(:prefecture).first
+      - if resource.errors.include?(:city)
+        .error_explanation
+          = resource.errors.full_messages_for(:city).first
+      - if resource.errors.include?(:house_number)
+        .error_explanation
+          = resource.errors.full_messages_for(:house_number).first
+      - if resource.errors.include?(:building_name)
+        .error_explanation
+          = resource.errors.full_messages_for(:building_name).first
     .field
       .field-label
         = f.label :phone_number, "電話番号"
       .field-input
         = f.text_field :phone_number, autofocus: true, autocomplete: "phone_number",placeholder: "080xxxoooo"
+      - if resource.errors.include?(:phone_number)
+        .error_explanation
+          = resource.errors.full_messages_for(:phone_number).first
     .actions
       = f.submit "登録する", class: 'btn'

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -11,12 +11,12 @@
       .field-input
         = f.text_field :family_name, autofocus: true, autocomplete: "family_name",placeholder: "田中"
         = f.text_field :first_name, autofocus: true, autocomplete: "first_name",placeholder: "太郎"
-      - if resource.errors.include?(:family_name)
+      - if @address.errors.include?(:family_name)
         .error_explanation
-          = resource.errors.full_messages_for(:family_name).first
-      - if resource.errors.include?(:first_name)
+          = @address.errors.full_messages_for(:family_name).first
+      - if @address.errors.include?(:first_name)
         .error_explanation
-          = resource.errors.full_messages_for(:first_name).first
+          = @address.errors.full_messages_for(:first_name).first
     .field
       .field-label
         = f.label :name_kana, "お名前（カナ）"
@@ -26,21 +26,21 @@
       .field-input
         = f.text_field :family_name_kana, autofocus: true, autocomplete: "family_name_kana",placeholder: "タナカ"
         = f.text_field :first_name_kana, autofocus: true, autocomplete: "first_name_kana",placeholder: "タロウ"
-      - if resource.errors.include?(:family_name_kana)
+      - if @address.errors.include?(:family_name_kana)
         .error_explanation
-          = resource.errors.full_messages_for(:family_name_kana).first
-      - if resource.errors.include?(:first_name_kana)
+          = @address.errors.full_messages_for(:family_name_kana).first
+      - if @address.errors.include?(:first_name_kana)
         .error_explanation
-          = resource.errors.full_messages_for(:first_name_kana).first
+          = @address.errors.full_messages_for(:first_name_kana).first
     .field
       .field-label
         = f.label :post_code, "郵便番号"
         %span.form-require 必須
       .field-input
         = f.text_field :post_code, autofocus: true, autocomplete: "post_code",placeholder: "0001111"
-      - if resource.errors.include?(:post_code)
+      - if @address.errors.include?(:post_code)
         .error_explanation
-          = resource.errors.full_messages_for(:post_code).first
+          = @address.errors.full_messages_for(:post_code).first
     .field
       .field-label
         = f.label :address, "住所"
@@ -53,25 +53,25 @@
         = f.text_field :house_number, autofocus: true, autocomplete: "house_number",placeholder: "番地"
         %br
         = f.text_field :building_name, autofocus: true, autocomplete: "building_name",placeholder: "建物名・部屋番号"
-      - if resource.errors.include?(:prefecture)
+      - if @address.errors.include?(:prefecture)
         .error_explanation
-          = resource.errors.full_messages_for(:prefecture).first
-      - if resource.errors.include?(:city)
+          = @address.errors.full_messages_for(:prefecture).first
+      - if @address.errors.include?(:city)
         .error_explanation
-          = resource.errors.full_messages_for(:city).first
-      - if resource.errors.include?(:house_number)
+          = @address.errors.full_messages_for(:city).first
+      - if @address.errors.include?(:house_number)
         .error_explanation
-          = resource.errors.full_messages_for(:house_number).first
-      - if resource.errors.include?(:building_name)
+          = @address.errors.full_messages_for(:house_number).first
+      - if @address.errors.include?(:building_name)
         .error_explanation
-          = resource.errors.full_messages_for(:building_name).first
+          = @address.errors.full_messages_for(:building_name).first
     .field
       .field-label
         = f.label :phone_number, "電話番号"
       .field-input
         = f.text_field :phone_number, autofocus: true, autocomplete: "phone_number",placeholder: "080xxxoooo"
-      - if resource.errors.include?(:phone_number)
+      - if @address.errors.include?(:phone_number)
         .error_explanation
-          = resource.errors.full_messages_for(:phone_number).first
+          = @address.errors.full_messages_for(:phone_number).first
     .actions
       = f.submit "登録する", class: 'btn'

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -119,7 +119,7 @@
         greater_than: は%{count}より大きい値にしてください
         greater_than_or_equal_to: は%{count}以上の値にしてください
         inclusion: は一覧にありません
-        invalid: は不正な値です
+        invalid: の入力方法を確認してください
         less_than: は%{count}より小さい値にしてください
         less_than_or_equal_to: は%{count}以下の値にしてください
         model_invalid: 'バリデーションに失敗しました: %{errors}'


### PR DESCRIPTION
# What
アカウントの新規登録ページとログインページの実装を行う。

# Why
フリマアプリケーションにおいて、ユーザーの登録・ログイン機能は必須だから。

# ビューの変更
・フォームの中央よせ
[![Image from Gyazo](https://i.gyazo.com/c1de8c1641fc8084fbcc8b5b0384148e.png)](https://gyazo.com/c1de8c1641fc8084fbcc8b5b0384148e)

・エラーメッセージの表示場所/表示内容
[![Image from Gyazo](https://i.gyazo.com/d9fd9399e69a80d1cba8fc8c2c5d53d1.png)](https://gyazo.com/d9fd9399e69a80d1cba8fc8c2c5d53d1)