### PR TITLE
Fixed buy__confirmation__btn

### DIFF
--- a/app/assets/stylesheets/_credit-card-buy.scss
+++ b/app/assets/stylesheets/_credit-card-buy.scss
@@ -57,5 +57,8 @@
       margin: 10px auto;
       display: block;
     }
+    a {
+      text-decoration: none;
+    }
   }
 }

--- a/app/views/credit_cards/buy.html.haml
+++ b/app/views/credit_cards/buy.html.haml
@@ -14,6 +14,7 @@
   .buy__confirmation
     .buy__confirmation__credit_cards
       = "クレジットカード番号：" + "#{" **** **** **** " + @customer_card.last4}"
-    .buy__confirmation__btn
-      購入する
+    = link_to pay_product_credit_card_path(@product), method: :post do
+      .buy__confirmation__btn 購入する
+
  


### PR DESCRIPTION
行ったこと

buy.html.haml
要素全体が購入ボタンとなり、
pay  アクションへ移行するように指定した。

_credit-card-buy.scss
buy__confirmation__btn のリンクの下線を削除
